### PR TITLE
Pull version 2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+In terms of this script the version number MAJOR.MINOR.PATCH would mean the following:
+
+- MAJOR version when the changes would need a review of the templates that were created in After Effects or the approach of media files being used,
+- MINOR version when you add functionality in a backwards-compatible manner, and
+- PATCH version when you make backwards-compatible bug fixes.
+
 ## [Planned]
+- Add a description to the README how the templates need to be set up to be handled by the script
+- Add a logging mechanism. The log file should be saved in the After Effects file folder, so in case of an error problems can be easily reproduced
+- Split configuration in global and user specific configurations (one approach might be to search for configuration settings within the current AE file's directory and the directories up where the subfolder's settings file overwrites the parent folder's settings)
+- Find out if it is possible to store some settings within the After Effects file
 - Fix problem with text layer's line counts so that for one line text layers the text isn't cut anymore but is split or font size is being reduced
 - Fix problem with keyframe types being changed when a split position of a text layer was changed
 - Create a configuration UI
@@ -12,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Create a UI to search for split texts within the resulting main comps
 - Thinking of saving changes made to text layers (e.g. splits at different positions) being saved in the `Comp for In and Out` composition
 - Create an option for being able to handle not only left oriented texts for fill ins
+- Try adding a Automatic Update functionality where the script is checking the GitHub master branch for a new version and updates the appropriate files accordingly
 
 ## [Work In Progress]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,20 +5,34 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Planned]
-- find a way to make the fontSize checks faster in `sbVideoScript.checkAndAdjustFontSize` (reduce fontSize to fit text into layer). The call textProp.setValue(textDocument) is very slow.
-- keyframes should be adjusted from the middle to the end of the duration instead of within the array of the minduration
-- create a configuration UI
-- review all layers and search for layers with splitted texts
+- Fix problem with text layer's line counts so that for one line text layers the text isn't cut anymore but is split or font size is being reduced
+- Fix problem with keyframe types being changed when a split position of a text layer was changed
+- Create a configuration UI
+- Create an option so save configuration settings
+- Create a UI to search for split texts within the resulting main comps
+- Thinking of saving changes made to text layers (e.g. splits at different positions) being saved in the `Comp for In and Out` composition
+- Create an option for being able to handle not only left oriented texts for fill ins
+
+## [Work In Progress]
 
 ## [Unreleased]
+
+## [2.4.1] - 2017-11-11
+### Changed
+- We are not storing the resulting comps and layer information in an object anymore. We did that to make it easier to review them later. But the created main compositions store all the relevant information in their layers thus this information is much more accurate and change resistant than storing a static object.
+- Renamed package to `saddleback-video-i18n`
+- Adding several fill in options: Fill In is shown from the beginning of the slide, Fill In is shown with animation (as it was before), and Fill In text is not shown within the slide
+
+### Fixed
+- Fixed problems with the fill in positions if a fill starts in the beginning of a line (line number > 1) or is spread over more than two lines (sbVideoScript.checkFillinLayerAddresses)
 
 ## [2.4.0] - 2017-10-05
 ### Fixed
 - The adjustment of font sizes didn't properly work for text layers with only one line
-- Solved problems in `sbVideoScript.adjustUIForSplittedLayers`: When a text included a `'` character jumping to a text layer with splitted text caused an error
+- Solved problems in `sbVideoScript.adjustUIForSplittedLayers`: When a text included a `'` character jumping to a text layer with split text caused an error
 - Minor corrections on README.md
-- The speed of the script is improved by not reducing the font size in single steps, but by continuously halving it.
-- enable/disable templates for dropdownlist within configuration UI
+- If the text was too large for one text layer, the script always took a long time to make the correct adjustments. The font size was reduced in single steps, which was very slow. Now the script jumps directly to the smallest possible font size. If the text matches, it jumps to a medium size and then halves it until the text matches. As a rule, the script works much faster. If the text doesn't fit, it jumps much faster into the split mode.
+- enable/disable templates for `dropdownlist` within configuration UI
 
 ## [2.3.1] - 2017-09-02
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Saddleback Video Translation
+# Saddleback Video i18n
 
 This app, created to help with the creation of translated video files, exists to fulfill these purposes:
 
@@ -20,9 +20,9 @@ Install the script as mentioned in the `Getting started` section. Before you can
 
 In your Applications folder search for `Adobe After Effects CC ...`. You will find a folder `Scripts/ScriptUI Panels` there. This is where we will put all the scripts material.
 
-Download the file `start.js` from the folder `src` from this repository and put it into the folder `ScriptUI Panels` as shown above. After restarting Adobe After Effects you will find this script in the Window menu in After Effects. It is helpfull to rename the script's name to something usefull like `Saddleback Video Translation`. It should have the extension `.jsx` otherwise it will not be recognised by Adobe After Effects.
+Download the file `start.js` from the folder `src` from this repository and put it into the folder `ScriptUI Panels` as shown above. After restarting Adobe After Effects you will find this script in the Window menu in After Effects. It is helpful to rename the script's name to something useful like `Saddleback Video i18n`. It should have the extension `.jsx` otherwise it will not be recognized by Adobe After Effects.
 
-In addition you need to create a subfolder with the name `(Saddleback Translation Script Supporting Functions)` within the `ScriptUI Panels` folder. Download all subfolders from the `src` folder from this repository into this supporting functions folder.
+In addition you need to create a subfolder with the name `(Saddleback Video i18n Functions)` within the `ScriptUI Panels` folder. Download all subfolders from the `src` folder from this repository into this supporting functions folder.
 
 Now you are ready to use the script.
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-    "name": "saddleback-video-translation",
-    "version": "2.4.0",
+    "name": "saddleback-video-i18n",
+    "version": "2.4.1",
     "description": "A script to help translate video components from one language into another in After Effects for Saddleback Church sermons.",
     "main": "index.js",
-    "repository": "git@github.com:TejasQ/SaddlebackVideoTranslation.git",
-    "author": "Tejas Kumar <tejas.kumar@mcmakler.de>",
+    "repository": "git@github.com:TejasQ/saddleback-video-i18n.git",
+    "author": "Carsten Koch<carsten.b.koch@gmail.com>",
     "license": "MIT",
     "devDependencies": {
     }

--- a/src/adjust-layers/add-text-to-layer-and-check-outcome.js
+++ b/src/adjust-layers/add-text-to-layer-and-check-outcome.js
@@ -10,24 +10,33 @@
         })
     }
 
-    sbVideoScript.addTextToLayerAndCheckOutcome = function (text, textLayer, result) {
+    sbVideoScript.addTextToLayerAndCheckOutcome = function (text, textLayer, lastResult) {
         try {
             var textProp = textLayer.property("Source Text");
             var lastBlLength = textProp.value.baselineLocs.length;
             textProp.setValue(text);
             var textDocument = textProp.value;
-            result.blLength = textDocument.baselineLocs.length;
             var bl = textDocument.baselineLocs;
-            result.lineY = bl[result.blLength-1];
-            result.lineStartX = bl[result.blLength-4];
-            result.lineEndX = bl[result.blLength-2];
+            lastBlLength = lastBlLength === 0 || lastBlLength > bl.length ? 4 : lastBlLength;
+            var lines = [];
 
-            // for every line break we add the lineEndX to an object
-            result.lastLineEndX = {};
-            while (result.blLength > lastBlLength) {
-                result.lastLineEndX[lastBlLength] = bl[lastBlLength-2];
-                lastBlLength += 4;
+            for (var i = lastBlLength; i <= bl.length; i += 4) {
+                var line = {};
+                if (i === lastBlLength && lastResult.length > 0) {
+                    var lastLine = lastResult[lastResult.length - 1];
+                    line.startX = lastLine.endX;
+                    line.startY = lastLine.endY;
+                } else {
+                    line.startX = bl[i-4];
+                    line.startY = bl[i-3];
+                }
+                line.endX = bl[i-2];
+                line.endY = bl[i-1];
+
+                lines.push(line);
             }
+
+            return lines;
 
         } catch (e) {
             throw new sbVideoScript.RuntimeError({

--- a/src/adjust-layers/add-text-to-layer-and-check-outcome.js
+++ b/src/adjust-layers/add-text-to-layer-and-check-outcome.js
@@ -17,6 +17,18 @@
             textProp.setValue(text);
             var textDocument = textProp.value;
             var bl = textDocument.baselineLocs;
+            var len = bl.length
+            var startAtNewLine = false;
+
+            if (bl[len-1] === bl[len-2] && bl[len-1] === bl[len-3] && bl[len-1] === bl[len-4]) {
+                text += 'CHECK';
+                textProp.setValue(text);
+                textDocument = textProp.value;
+                bl = textDocument.baselineLocs;
+                len = bl.length
+                startAtNewLine = true;
+            }
+
             lastBlLength = lastBlLength === 0 || lastBlLength > bl.length ? 4 : lastBlLength;
             var lines = [];
 
@@ -30,8 +42,13 @@
                     line.startX = bl[i-4];
                     line.startY = bl[i-3];
                 }
-                line.endX = bl[i-2];
-                line.endY = bl[i-1];
+                if (i === bl.length && startAtNewLine) {
+                    line.endX = line.startX;
+                    line.endY = line.startY;
+                } else {
+                    line.endX = bl[i-2];
+                    line.endY = bl[i-1];
+                }
 
                 lines.push(line);
             }

--- a/src/adjust-layers/check-fillin-layer-addresses.js
+++ b/src/adjust-layers/check-fillin-layer-addresses.js
@@ -55,6 +55,9 @@
                     restText = restText.substring(pos+len, restText.length);
 
                 } else {
+                    if (restText.length > 0) {
+                        textAry.push({text: restText});
+                    }
                     textFullyChecked = true;
                 }
             }

--- a/src/adjust-layers/create-and-position-masks-and-lines.js
+++ b/src/adjust-layers/create-and-position-masks-and-lines.js
@@ -4,6 +4,7 @@
     try {
         importScript('errors/runtime-error');
         importScript('adjust-layers/adjust-pre-composed-comp-size');
+        importScript('remove-keyframes-and-set-opacity');
 
     } catch (e) {
         throw new sbVideoScript.RuntimeError({
@@ -15,6 +16,8 @@
 
     sbVideoScript.createAndPositionMasksAndLines = function (maskAddr, mask, line, base, parentFolder) {
         try {
+            // maskAddr = { maskAddresses, textMaskHandling }
+
             var tolerancePx = sbVideoScript.settings.tolerancePxForMaskPositioning;
             var contComp = mask.containingComp;
             var preComposePrefix = contComp.name.substring(0,7) + sbVideoScript.settings.preComposedMaskLayerExtension;
@@ -22,49 +25,69 @@
             var masksForPreCompose = [];
             var parentLayer = mask.parent;
 
+            // count mask address lines
+            var numOfLines = 0;
+            for (var i = 0; i < maskAddr.length; i++) {
+                numOfLines += maskAddr[i].positions.length;
+            }
+
             // if I need more than one fill in make the mask layer visible
             // we will later pre-compose all mask layers and
             // we will than make the pre-composition invisible again
-            if (maskAddr.length > 1) {
+            if (numOfLines > 1) {
                 mask.enabled = true;
             }
+
             // iterate through all mask addresses from top to down
-            for (var i = maskAddr.length - 1; i >= 0; i--) {
-                var currMask = {};
-                if (i === 0) {
-                    // if I only need one fill in nothing needs to be created
-                    currMask = mask;
-                } else {
-                    // if I need more than one fill in
-                    // duplicate the maskLayer
-                    // duplicate the lineLayer and set the new maskLayer as parent
-                    currMask = mask.duplicate();
-                    line.duplicate().parent = currMask;
+            for (var i = maskAddr.length-1; i >= 0; i--) {
+                var addr = maskAddr[i];
+
+                for (var j = addr.positions.length-1; j >= 0; j--) {
+                    var adr = addr.positions[j];
+                    var currMask = {};
+
+                    if (i+j === 0) {
+                        // if I only need one fill in nothing needs to be created
+                        currMask = mask;
+                    } else {
+                        // if I need more than one fill in
+                        // duplicate the maskLayer
+                        // duplicate the lineLayer and set the new maskLayer as parent
+                        currMask = mask.duplicate();
+                        line.duplicate().parent = currMask;
+                    }
+
+                    // apply expected animation for the new mask
+                    var handling = addr.textMaskHandling;
+                    if (handling === 'show') {
+                        sbVideoScript.removeKeyframesAndSetOpacity(currMask, 0);
+                    } else if (handling === 'hide') {
+                        sbVideoScript.removeKeyframesAndSetOpacity(currMask, 100);
+                    }
+
+                    // save the mask for later pre composing
+                    masksForPreCompose.push(currMask);
+
+                    // position the mask and size it
+                    var maskPropPos = currMask.property("Position");
+                    var posMask = maskPropPos.value;
+                    var moveX = adr.startX - base.x - tolerancePx;
+                    var moveY = adr.startY - base.y;
+                    var width = adr.endX - adr.startX + tolerancePx * 2;
+                    posMask[0] += moveX;
+                    posMask[1] += moveY;
+                    maskPropPos.setValue(posMask);
+
+                    var maskPropScale = currMask.property("Scale");
+                    var orgMaskWidth = currMask.sourceRectAtTime(sbVideoScript.settings.animationProtectionTime, true).width;
+                    var newScale = maskPropScale.value;
+                    newScale[0] = width / orgMaskWidth * newScale[0];
+                    maskPropScale.setValue(newScale);
                 }
-                var adr = maskAddr[i];
-
-                // save the mask for later pre composing
-                masksForPreCompose.push(currMask);
-
-                // position the mask and size it
-                var maskPropPos = currMask.property("Position");
-                var posMask = maskPropPos.value;
-                var moveX = adr.startX - base.x - tolerancePx;
-                var moveY = adr.y - base.y;
-                var width = adr.endX - adr.startX + tolerancePx * 2;
-                posMask[0] += moveX;
-                posMask[1] += moveY;
-                maskPropPos.setValue(posMask);
-
-                var maskPropScale = currMask.property("Scale");
-                var orgMaskWidth = currMask.sourceRectAtTime(sbVideoScript.settings.animationProtectionTime, true).width;
-                var newScale = maskPropScale.value;
-                newScale[0] = width / orgMaskWidth * newScale[0];
-                maskPropScale.setValue(newScale);
             }
 
             // put all masks into a precomp
-            if (maskAddr.length > 1) {
+            if (numOfLines > 1) {
                 var items = [];
                 for (var t = 0, ml = masksForPreCompose.length; t < ml; t++) {
                     items.push(masksForPreCompose[t].index);

--- a/src/adjust-layers/create-and-position-masks-and-lines.js
+++ b/src/adjust-layers/create-and-position-masks-and-lines.js
@@ -4,7 +4,7 @@
     try {
         importScript('errors/runtime-error');
         importScript('adjust-layers/adjust-pre-composed-comp-size');
-        importScript('remove-keyframes-and-set-opacity');
+        importScript('adjust-layers/remove-keyframes-and-set-opacity');
 
     } catch (e) {
         throw new sbVideoScript.RuntimeError({

--- a/src/adjust-layers/remove-keyframes-and-set-opacity.js
+++ b/src/adjust-layers/remove-keyframes-and-set-opacity.js
@@ -1,0 +1,33 @@
+{
+    try {
+        importScript('errors/runtime-error');
+
+    } catch (e) {
+        throw new sbVideoScript.RuntimeError({
+            func: "importScript's for removeKeyframesAndSetOpacity",
+            title: 'Error loading neccesary functions',
+            message: e.message
+        })
+    }
+
+    sbVideoScript.removeKeyframesAndSetOpacity = function (layer, newOpacity) {
+        try {
+            var opacity = layer.property("Opacity");
+            var opacityNumKeys = opacity.numKeys;
+            if (opacity.canVaryOverTime) {
+                while (opacityNumKeys > 0) {
+                    opacity.removeKey(opacityNumKeys);
+                    opacityNumKeys = opacity.numKeys;
+                }
+            }
+            opacity.setValue(newOpacity);
+
+        } catch (e) {
+            throw new sbVideoScript.RuntimeError({
+                func: 'removeKeyframesAndSetOpacity',
+                title: "Error while removing keyframes and set opacity",
+                message: e.message
+            })
+        }
+    }
+}

--- a/src/adjust-layers/update-text-layers.js
+++ b/src/adjust-layers/update-text-layers.js
@@ -3,7 +3,7 @@ Update the text layer of a given comp.
 
 @Usage this is used to replace the text in duplicated "German" comps with text from a file.
 @param comp {Object} - a composition.
-@param textLayers {Array} - an array of text layers with its name and new content.
+@param parsedContentLine {Object} - an object which contains the information of a certain line of the CSV file in form of a structured object. parsedContentLine.layers stores the text layers with its originalLayerName, layerName and the text itself
 @param parentFolder {Object} - the parentFolder where pre-composed layers will be consolidated
 */
 
@@ -27,7 +27,11 @@ Update the text layer of a given comp.
             if (!comp) { throw new Error("No composition provided") }
 
             var textLayers = parsedContentLine.layers;
-            var fillInDelimiter = sbVideoScript.settings.fillInDelimiter;
+
+            // DONE add several fill in options here
+            // var fillInDelimiter = sbVideoScript.settings.fillInDelimiter;
+            var fillInHandling = sbVideoScript.settings.fillInHandling;
+
             var resultingTextLayers = [];
 
             // let's check if we have permission to split the text
@@ -52,7 +56,15 @@ Update the text layer of a given comp.
                     var textLayer = comp.layer(layerName);
 
                     if (textLayer) {
-                        var resultText = newText.replace(fillInDelimiter[0],'').replace(fillInDelimiter[1],'');
+                        // remove all possible fill in delimiters within the text to just handle the pure text
+                        var resultText = newText;
+                        for (var fillInOption in fillInHandling) {
+                            var delimiter = fillInHandling[fillInOption].delimiter;
+                            var len = delimiter.length / 2;
+                            var delimiterLeft = delimiter.substring(0, len);
+                            var delimiterRight = delimiter.substring(len, len*2);
+                            resultText = resultText.replace(delimiterLeft,'').replace(delimiterRight,'');
+                        }
 
                         // store baselines assuming the mask and line start at the very
                         // left of the template text and we only need to know how far
@@ -84,7 +96,10 @@ Update the text layer of a given comp.
                             // evaluate if there is more than one fill in
                             // or a fill in is splitted over lines
                             // if this is the case than duplicate masks and lines and precompose them
-                            var arrOfMaskAddresses = sbVideoScript.checkFillinLayerAddresses(newText, textLayer, fillInDelimiter);
+
+                            // DONE add several fill in options here
+                            // var arrOfMaskAddresses = sbVideoScript.checkFillinLayerAddresses(newText, textLayer, fillInDelimiter);
+                            var arrayOfMaskAddresses = sbVideoScript.checkFillinLayerAddresses(newText, textLayer);
 
                             var maskLayerName = sbVideoScript.settings.maskLayerNamePrefix + ' ' + layerName[layerName.length - 1];
                             var maskLayer = comp.layer(maskLayerName);
@@ -93,17 +108,20 @@ Update the text layer of a given comp.
 
                             // check if there is no fill in and hide the mask and the line
                             // check if there is more than one fill in
-                            if (arrOfMaskAddresses.length === 0) {
+                            // if (arrOfMaskAddresses.length === 0) {
+                            if (arrayOfMaskAddresses.length === 0) {
                                 textLayer.trackMatteType = TrackMatteType.NO_TRACK_MATTE;
                                 if (lineLayer) {
                                     lineLayer.remove();
                                 }
                             } else {
-                                // TODO: check for expected maskLayer and lineLayer within load-all-expected-templates +enhancement id:78 gh:23
                                 if (maskLayer) {
                                     if (lineLayer) {
                                         // fill ins found, so we need to create and position the mask layers
-                                        sbVideoScript.createAndPositionMasksAndLines(arrOfMaskAddresses, maskLayer, lineLayer, baselines, parentFolder);
+                                        // DONE handle several fill in options here
+                                        // sbVideoScript.createAndPositionMasksAndLines(arrOfMaskAddresses, maskLayer, lineLayer, baselines, parentFolder);
+                                        sbVideoScript.createAndPositionMasksAndLines(arrayOfMaskAddresses, maskLayer, lineLayer, baselines, parentFolder);
+
                                     } else {
                                         // if lineLayer doesn't exist something is wrong with the template
                                         throw new Error("The current composition '"+ comp.name +"' shows that the layer '"+ lineLayerName +"' is missing. Please correct and run the script again.");

--- a/src/adjust-timeline/extend-comp-duration.js
+++ b/src/adjust-timeline/extend-comp-duration.js
@@ -81,11 +81,21 @@
             comp.duration += offset;
 
         } catch (e) {
+            var compInfo = "";
+            try {
+                compInfo += "compName = "+ comp.name;
+                compInfo += "; shouldCompDuration = "+ Math.floor(shouldCompDuration);
+                compInfo += "; protection = "+ Math.floor(protection);
+                compInfo = "[composition information: "+ compInfo +"]";
+            } catch (e) {
+                compInfo = "["+ compInfo +"; wasn't able to retrieve composition's information]";
+            }
+
             throw new sbVideoScript.RuntimeError({
                 func: 'extendCompDuration',
-                title: "Error extending the duration of the composition",
+                title: 'Error extending the duration of the composition: '+ compInfo,
                 message: e.message
-            })
+            });
         }
     }
 }

--- a/src/adjust-timeline/extend-layer-duration.js
+++ b/src/adjust-timeline/extend-layer-duration.js
@@ -84,11 +84,19 @@
             }
 
         } catch (e) {
+            var propertyInfo = "";
+            try {
+                propertyInfo += "pGroupName = "+ pGroup.name;
+                propertyInfo = "[composition information: "+ propertyInfo +"]";
+            } catch (e) {
+                propertyInfo = "["+ propertyInfo +"; wasn't able to retrieve property's information]";
+            }
+
             throw new sbVideoScript.RuntimeError({
                 func: 'extendLayerDuration',
-                title: "Error extending the duration of the layer",
+                title: 'Error extending the duration of the layer: '+ propertyInfo,
                 message: e.message
-            })
+            });
         }
 
     }

--- a/src/adjust-timeline/place-comp-in-timeline.js
+++ b/src/adjust-timeline/place-comp-in-timeline.js
@@ -38,9 +38,18 @@ it will be splitted in three parts: beginning, middle and end.
             return comp.name;
 
         } catch (e) {
+            var compInfo = "";
+            try {
+                compInfo += "targetCompName = "+ targetComp.name;
+                compInfo += "; compName = "+ comp.name;
+                compInfo = "[composition information: "+ compInfo +"]";
+            } catch (e) {
+                compInfo = "["+ compInfo +"; wasn't able to retrieve composition's information]";
+            }
+
             throw new sbVideoScript.RuntimeError({
                 func: 'placeCompInTimeline',
-                title: "Error placing composition in timeline",
+                title: 'Error placing composition in timeline: '+ compInfo,
                 message: e.message
             })
         }

--- a/src/config/configuration.js
+++ b/src/config/configuration.js
@@ -66,7 +66,7 @@
             },
             splitSettings: {
                 splitPositions: {
-                    allTexts: ['. ', '? ', '! ', '; ', ', ', ' - ', ' – ', '...', '…'],
+                    allTexts: ['. ', '? ', '! ', '; ', ', ', ' - ', ' – ', '...', '…', '. . .'],
                     'Text German': ['und'],
                     'Text English': ['and', 'than', 'then'],
                 },
@@ -115,7 +115,20 @@
             standardCSVDelimiter: "\t",
             maskLayerNamePrefix: 'Mask',
             lineLayerNamePrefix: 'Line',
-            fillInDelimiter: '[]',
+            fillInHandling: {
+                showFromBeginning: {
+                    delimiter: '&&&&',
+                    textMaskHandling: 'show'
+                },
+                showWithAnimation: {
+                    delimiter: '[]',
+                    textMaskHandling: 'animate'
+                },
+                hideText: {
+                    delimiter: '§§§§',
+                    textMaskHandling: 'hide'
+                }
+            },
             delimiterForNewLines: '{n}',
             maximumFontSizeChange: -0.15,
             animationProtectionTime: 2,

--- a/src/config/configuration.js
+++ b/src/config/configuration.js
@@ -32,10 +32,22 @@
                 'Full Screen 3-lines': {
                     youtubeAlternative: false,
                     isSizeAlternative: true,
-                    sizeAlternative: 'Full Screen YouTube',
+                    sizeAlternative: 'Full Screen 4-lines',
+                    isSelectable: false
+                },
+                'Full Screen 4-lines': {
+                    youtubeAlternative: false,
+                    isSizeAlternative: true,
+                    sizeAlternative: 'Two Columns',
                     isSelectable: false
                 },
                 'Full Screen YouTube': {
+                    youtubeAlternative: false,
+                    isSizeAlternative: true,
+                    sizeAlternative: 'Full Screen YouTube smaller',
+                    isSelectable: false
+                },
+                'Full Screen YouTube smaller': {
                     youtubeAlternative: false,
                     isSizeAlternative: false,
                     isSelectable: false
@@ -125,7 +137,7 @@
                     textMaskHandling: 'animate'
                 },
                 hideText: {
-                    delimiter: '§§§§',
+                    delimiter: '$$$$',
                     textMaskHandling: 'hide'
                 }
             },

--- a/src/csv-file-handling/create-slide-for-main-comp.js
+++ b/src/csv-file-handling/create-slide-for-main-comp.js
@@ -1,10 +1,3 @@
-/**
-Create all compositions from a given text file based on templates.
-
-@IMPORTANT: You MUST have a default template composition for the different
-"types" of compositions => "Scripture", "Lower Third", etc.
-*/
-
 {
     try {
         importScript('errors/runtime-error');
@@ -40,13 +33,7 @@ Create all compositions from a given text file based on templates.
                     var newComp = sbVideoScript.createCompFromTemplate(templateName, line, main.footageFolder);
 
                     try {
-                        // DOING check if I really need to store resulting layers and text layer information +enhancement id:95 gh:39
                         resultingTextLayers = sbVideoScript.updateTextLayers(newComp, parsedContentLine, main.footageFolder);
-                        resultingLayer = {
-                            line: line,
-                            compType: templateName,
-                            textLayers: resultingTextLayers
-                        }
                     } catch (e) {
                         if (e instanceof sbVideoScript.FontToSmallError) {
                             var cfg = sbVideoScript.settings.compositionTemplates[templateName];
@@ -70,11 +57,7 @@ Create all compositions from a given text file based on templates.
                 var cfg = sbVideoScript.settings.compositionTemplates[templateName];
                 startTime = startTime - cfg.inBgFullyCovered;
                 endTime = endTime + cfg.outBgFullyCovered;
-                resultingLayer.layerName = sbVideoScript.placeCompInTimeline(newComp, main.comp, startTime, endTime, resultingTextLayers);
-                resultingLayer.startTime = startTime - 2 / main.frameRate;
-                resultingLayer.endTime = endTime + 2 / main.frameRate;
-
-                return resultingLayer;
+                sbVideoScript.placeCompInTimeline(newComp, main.comp, startTime, endTime, resultingTextLayers);
             }
 
         } catch (e) {
@@ -82,6 +65,7 @@ Create all compositions from a given text file based on templates.
             try {
                 mainCompInfo += "mainCompName = "+ main.comp.name;
                 mainCompInfo += "; templateName = "+ templateName;
+                mainCompInfo += "; lineNumber = "+ line;
                 mainCompInfo = "[main composition information: "+ mainCompInfo +"]";
             } catch (e) {
                 mainCompInfo = "["+ mainCompInfo +"; wasn't able to retrieve main composition's information]";

--- a/src/start.js
+++ b/src/start.js
@@ -4,7 +4,7 @@
         var fileAlreadyLoaded = sbVideoScript.filesLoaded[fileName];
         if (!fileAlreadyLoaded) {
             try {
-                var mainDirectory = '(Saddleback Translation Script Supporting Functions)/';
+                var mainDirectory = '(Saddleback Video i18n Functions)/';
                 var extension = '.js';
                 var file = new File(mainDirectory + fileName + extension);
                 file.open("r");

--- a/src/ui-onclick-functions/create-slides.js
+++ b/src/ui-onclick-functions/create-slides.js
@@ -1,5 +1,3 @@
-// TODO: do I really need the resultingMainComps? +enhancement id:97 gh:41
-
 {
     try {
         importScript('errors/runtime-error');
@@ -25,7 +23,6 @@
             var compForInOuts = sbVideoScript.getCompItem(sbVideoScript.settings.compositionNameForInOuts);
             var mainComps = sbVideoScript.settings.mainCompositionsToBuild;
             var mainCompsConfig = mainComps.compositionsConfig;
-            var resultingMainComps = {};
 
             if (!(compForInOuts && mainComps)) { throw new Error("Please make sure you first load the content and create a composition which shows the in/out points of the slides and content being used") }
 
@@ -38,15 +35,7 @@
 
                 main.comp.openInViewer();
 
-                var resultingLayers = [];
-                resultingMainComps[main.comp.name] = {
-                    comp: main.comp,
-                    layers: resultingLayers,
-                };
-
                 app.beginUndoGroup("Creating Slides for '" + main.comp.name + "'");
-
-                // TODO: Add a progress bar when creating the main compositions and their slides +feature gh:60 id:3
 
                 var layerLen = compForInOuts.layers.length - 1;
                 for (var l = layerLen; l > 0; l--) {
@@ -60,8 +49,7 @@
                     var templateName = layerNameArr.join(' ');
                     var startTime = layer.inPoint;
                     var endTime = layer.outPoint;
-                    var resultingLayer = sbVideoScript.createSlideForMainComp(main, csvLine, lineNumber, colPos, compConfig, startTime, endTime, templateName);
-                    resultingLayers.push(resultingLayer);
+                    sbVideoScript.createSlideForMainComp(main, csvLine, lineNumber, colPos, compConfig, startTime, endTime, templateName);
                 }
 
                 // master the audio and add the main comp to the render queue


### PR DESCRIPTION
## [2.4.1] - 2017-11-11
### Changed
- We are not storing the resulting comps and layer information in an object anymore. We did that to make it easier to review them later. But the created main compositions store all the relevant information in their layers thus this information is much more accurate and change resistant than storing a static object.
- Renamed package to `saddleback-video-i18n`
- Adding several fill in options: Fill In is shown from the beginning of the slide, Fill In is shown with animation (as it was before), and Fill In text is not shown within the slide

### Fixed
- Fixed problems with the fill in positions if a fill starts in the beginning of a line (line number > 1) or is spread over more than two lines (sbVideoScript.checkFillinLayerAddresses)
